### PR TITLE
Fixes gzip plugin configuration syntax.

### DIFF
--- a/webpack/config.production.js
+++ b/webpack/config.production.js
@@ -34,7 +34,7 @@ module.exports = {
       }
     }),
     new CompressionPlugin({
-      asset: '{file}.gz',
+      asset: '[file].gz',
       algorithm: 'gzip',
       test: /\.css$|\.js$|\.html$/,
       threshold: 10240,


### PR DESCRIPTION
According to https://github.com/webpack/compression-webpack-plugin and to what works on my computer.
